### PR TITLE
Fixed water heater mode naming

### DIFF
--- a/components/smartboiler/SBProtocol.h
+++ b/components/smartboiler/SBProtocol.h
@@ -92,7 +92,17 @@ enum SBPacket : uint16_t {
   SBC_PACKET_STATISTICS_YEAR = 91,
 };
 
-static const char *modeStrings[] = {"STOP", "NORMAL", "HDO", "SMART", "SMARTHDO", "ANTIFROST", "NIGHT", "TEST"};
+enum Mode: uint8_t {
+  STOP = 0,
+  // MANUAL/HDO is selected based on HDO setting in water heater
+  MANUAL = 1,
+  HDO = 2,
+  // SMART/SMART_HDO is selected based on HDO setting in water heater
+  SMART = 3,
+  SMART_HDO = 4,
+  ANTIFREEZE = 5,
+  PROG = 6,
+};
 
 class SBProtocolRequest {
  public:

--- a/components/smartboiler/__init__.py
+++ b/components/smartboiler/__init__.py
@@ -88,7 +88,7 @@ async def to_code(config):
         cg.add(var.set_heat_on(sens))
 
     if CONF_MODE in config:
-        sel = await select.new_select(config[CONF_MODE], options=['STOP', 'NORMAL', 'HDO', 'SMART', 'SMARTHDO', 'ANTIFROST', 'NIGHT', 'TEST'])
+        sel = await select.new_select(config[CONF_MODE], options=['ANTIFREEZE', 'SMART', 'PROG', 'MANUAL'])
         cg.add(var.set_mode(sel))
         await cg.register_parented(sel, var)
 

--- a/components/smartboiler/smartboiler.h
+++ b/components/smartboiler/smartboiler.h
@@ -19,6 +19,11 @@ namespace sb {
 static const uint8_t MIN_TEMP = 40;
 static const uint8_t MAX_TEMP = 80;
 
+static const std::string MODE_ANTIFREEZE = "ANTIFREEZE";
+static const std::string MODE_SMART = "SMART";
+static const std::string MODE_PROG = "PROG";
+static const std::string MODE_MANUAL = "MANUAL";
+
 class SmartBoilerModeSelect;
 class SmartBoilerThermostat;
 class SmartBoilerPinInput;
@@ -71,6 +76,7 @@ class SmartBoiler : public PollingComponent,
   std::string generateUUID();
   const char *state_to_string(ConnectionState state);
   uint8_t convert_action_to_mode(const std::string &payload);
+  std::string convert_mode_to_action(const uint8_t mode);
 
   ESPPreferenceObject pref_;
   // state of the connection
@@ -104,6 +110,10 @@ class SmartBoiler : public PollingComponent,
   friend class SmartBoilerModeSelect;
   friend class SmartBoilerThermostat;
   friend class SmartBoilerPinInput;
+
+private:
+  bool isHdoEnabled = false;
+  
 };
 
 class SmartBoilerModeSelect : public esphome::select::Select, public esphome::Parented<SmartBoiler> {


### PR DESCRIPTION
Fixed naming of operation modes to match the iOS/Android app and the physical mode selector knob.