### PR TITLE
automatically set water heater time

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # ESPHome component for Dražice OKHE smart water heater
 
-This ESPHome components connects to Dražice OKHE smart water heaters via Bluetooth Low Energy, collects data and also allows for limited remote control.
+This ESPHome component connects to Dražice OKHE smart water heaters via Bluetooth Low Energy, collects data, and also allows for limited remote control.
 
 You will need an ESP32 module and an MQTT server. You also need to determine the MAC address of your water heater. See an [example configuration](example.yaml).
 
-Take note that only one device can be connected to the water heater at a time.
+Note that only one device can be connected to the water heater at a time.
 
 ## Documentation
 
-This ESPHome components uses couple of standard components (sensors etc.) for easy HomeAssistant integration (auto-discovery). While it uses MQTT, it's also possible to remove MQTT and setup HA integration directly via `api:` option.
+This ESPHome component uses several standard components (sensors, etc.) for easy Home Assistant integration (auto-discovery). While it uses MQTT, it's also possible to remove MQTT and set up HA integration directly via the `api:` option.
 
-### water heater outputs
+### Water heater outputs
 
 | Binary sensors | |
 | --- | --- |
@@ -19,21 +19,21 @@ This ESPHome components uses couple of standard components (sensors etc.) for ea
 
 | Sensors | |
 | --- | --- |
-| Temp1  | Temperature detected by lower temp sensor. |
-| Temp2  | Temperature detected by upper temp sensor (this is the temp displayed on the water heater). |
+| Temp1  | Temperature detected by lower temperature sensor |
+| Temp2  | Temperature detected by upper temperature sensor (this is the temperature displayed on the water heater) |
 | Normal temperature | Configured target temperature in NORMAL/HDO mode |
-| Energy | energy consumed since last reset (in kWh) |
+| Energy | Energy consumed since last reset (in kWh) |
 
 | Text sensors | |
 | --- | --- |
-| Version | firmware version, board version and serial number |
-| State |  connection state: Disconnected / Authenticating / Require PIN / Disconnected |
-| Name  |  name of the water heater unit |
+| Version | Firmware version, board version, and serial number |
+| State | Connection state: Disconnected / Authenticating / Require PIN / Connected |
+| Name  | Name of the water heater unit |
 
 | Inputs | |
 | --- | --- |
-| Pairing PIN | input to set pairing PIN |
-| Mode  |  set one of the operating modes |
+| Pairing PIN | Input to set pairing PIN |
+| Mode  | Set one of the operating modes |
 
 ### Modes
 
@@ -41,25 +41,25 @@ This is the list of recognized mode values. See the [original app](https://play.
 
 | Value           | Notes                       |
 | --------------- | --------------------------- |
-| STOP            | cannot be set               |
-| NORMAL          | can be set if hdo_enabled=0 |
-| HDO             | can be set if hdo_enabled=1 |
-| SMART           | can be set if hdo_enabled=0 |
-| SMARTHDO        | can be set if hdo_enabled=1 |
+| STOP            | Cannot be set               |
+| NORMAL          | Can be set if hdo_enabled=0 |
+| HDO             | Can be set if hdo_enabled=1 |
+| SMART           | Can be set if hdo_enabled=0 |
+| SMARTHDO        | Can be set if hdo_enabled=1 |
 | ANTIFROST       |                             |
 | NIGHT           |                             |
 
-Toggling mode will also enable/disable HDO based on selected mode -  NORMAL/HDO and SMART/SMARTHDO.
+Toggling mode will also enable/disable HDO based on the selected mode - NORMAL/HDO and SMART/SMARTHDO.
 
 ## Pairing process
 
-The water heater requires the client to be "authenticated" in order to communicate. The client generates some random UUID, sends it to the water heater and the water heater responds with request for pairing and shows PIN on the display.
+The water heater requires the client to be "authenticated" in order to communicate. The client generates a random UUID, sends it to the water heater, and the water heater responds with a request for pairing and shows a PIN on the display.
 
-This component allows to set pairing PIN and complete the pairing procees from HomeAssistant.
+This component allows you to set the pairing PIN and complete the pairing process from Home Assistant.
 
-### 1. configure ESP device
+### 1. Configure ESP device
 
-Create a configuration for ESP (see [example](example.yaml) for details). Component allows to define multiple water heaters to connect to (max 3). You need to know water heater BT MAC address (use any BT scanner to listen for BLE announcements. Please note that water heater sends announcements only when no device is connected.)
+Create a configuration for ESP (see [example](example.yaml) for details). The component allows you to define multiple water heaters to connect to (max 3). You need to know the water heater's Bluetooth MAC address (use any BT scanner to listen for BLE announcements. Please note that the water heater sends announcements only when no device is connected).
 
 ```yaml
 esphome:
@@ -68,7 +68,8 @@ esphome:
 esp32:
   board: nodemcu-32s
   framework:
-    type: arduino
+    type: esp-idf
+    version: recommended
 
 substitutions:
   mac_water_heater: XX:XX:XX:XX:XX:XX
@@ -130,19 +131,19 @@ wifi:
 
 ```
 
-I strongly recommend adding a switch to enable/disable the monitoring. The water heater allows to connect only one device at a time and you might need to disconnect the monitoring when you want to use mobile application for some complex setting or firmware upgrade.
+I strongly recommend adding a switch to enable/disable the monitoring. The water heater allows only one device to connect at a time, and you might need to disconnect the monitoring when you want to use the mobile application for some complex settings or firmware upgrades.
 
 ### 2. Pairing with PIN
 
-Once you flash ESP32 and power it on, it will autogenerate random UUID and try to connect to the water heater. Since it's not paired yet, it will end up in `Require PIN` state (with PIN visible on water heater display). At this moment you can enter the PIN in Home Assistant and it will finish the pairing process.
+Once you flash the ESP32 and power it on, it will auto-generate a random UUID and try to connect to the water heater. Since it's not paired yet, it will end up in the `Require PIN` state (with the PIN visible on the water heater display). At this moment, you can enter the PIN in Home Assistant and it will finish the pairing process.
 
 > **Important:**\
-> The water heater keeps PIN visible only for about 20 seconds, then it disconnects the client and the pairing process restarts. water heater generates always new PIN on each attempt. Wait for HA until it shows state `Require PIN` and only then enter the PIN.\
+> The water heater keeps the PIN visible only for about 20 seconds, then it disconnects the client and the pairing process restarts. The water heater always generates a new PIN on each attempt. Wait for HA until it shows the state `Require PIN` and only then enter the PIN.\
 \
-Changing/setting PIN in other states is ignored.\
-Once the pairing is completed (state is `Connected`), PIN value is also ignored.
+Changing/setting the PIN in other states is ignored.\
+Once the pairing is completed (state is `Connected`), the PIN value is also ignored.
 
-The ESP32 stores UUID in NVM and pairing is persistent between restarts.
+The ESP32 stores the UUID in NVM and pairing is persistent between restarts.
 
 ### How to reset UUID
 
@@ -155,12 +156,12 @@ esptool.py --chip esp32 --port /dev/ttyUSB0 write_flash 0x009000 nvs_zero
 
 ## Multiple water heaters on the same ESP32
 
-It's possible to connect ESP to multiple water heaters simultaneously (up to three). See [example_multiple.yaml](example_multiple.yaml).
+It's possible to connect an ESP to multiple water heaters simultaneously (up to three). See [example_multiple.yaml](example_multiple.yaml).
 
 **IMPORTANT:**
 
-when testing multiple water heaters (BLE clients) on ESPHome 2023.3.x, I have found it to be very unstable (keeps restarting frequently, disconnects, even up to the point it's not possible to finish OTA update). When you want to define multiple heaters on single ESP, I recommend to use older **ESPHome 2022.11.5** which I found somewhat stable.
+When testing multiple water heaters (BLE clients) on ESPHome 2023.3.x, I have found it to be very unstable (keeps restarting frequently, disconnects, even up to the point where it's not possible to finish OTA updates). When you want to define multiple heaters on a single ESP, I recommend using the older **ESPHome 2022.11.5** which I found somewhat stable.
 
-As a general rule, given the price of ESP32 devices, it's best to use dedicated ESP32 for each water heater.
+As a general rule, given the price of ESP32 devices, it's best to use a dedicated ESP32 for each water heater.
 
-![Home assistant](HA.png)
+![Home Assistant](HA.png)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ You will need an ESP32 module and an MQTT server. You also need to determine the
 
 Note that only one device can be connected to the water heater at a time.
 
+## Hardware
+
+This component has been tested on:
+* ESP32 dev board
+* ESP32-C3
+
 ## Documentation
 
 This ESPHome component uses several standard components (sensors, etc.) for easy Home Assistant integration (auto-discovery). While it uses MQTT, it's also possible to remove MQTT and set up HA integration directly via the `api:` option.
@@ -14,7 +20,7 @@ This ESPHome component uses several standard components (sensors, etc.) for easy
 
 | Binary sensors | |
 | --- | --- |
-| HDO | On when low energy tariff is currently active |
+| HDO | On if HDO detection is enabled in the water heater |
 | Heat | On when the water heater is currently heating (consuming energy) |
 
 | Sensors | |
@@ -73,6 +79,11 @@ esp32:
 
 substitutions:
   mac_water_heater: XX:XX:XX:XX:XX:XX
+
+# Enable time component. This will be used to set the time on the water heater.
+time:
+  - platform: homeassistant
+    id: esphome_time
 
 external_components:
   - source: 
@@ -144,6 +155,11 @@ Changing/setting the PIN in other states is ignored.\
 Once the pairing is completed (state is `Connected`), the PIN value is also ignored.
 
 The ESP32 stores the UUID in NVM and pairing is persistent between restarts.
+
+### Setting time on water heater
+The water heater has internal clock which measure date-less time (only day of the week and hours, minutes and seconds). This is used for scheduling of water heater stated or temperatures (available only in original app). For that, it's necessary that water heater has proper time set up. Unfortunately, the time is lost after power outage and needs to be set up again.
+
+By enabling time ESPHome component (see YAML), we use the time from the HomeAssistant to adjust/setup the time if it differs more than 30 seconds. That keeps the the water heater time in sync with HomeAssistant.
 
 ### How to reset UUID
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ ble_client:
 
 smartboiler:
   - ble_client_id: drazice_okhe
+    time_id: esphome_time
     temp1:
       name: "Water heater temp1"
     temp2:
@@ -159,7 +160,7 @@ The ESP32 stores the UUID in NVM and pairing is persistent between restarts.
 ### Setting time on water heater
 The water heater has internal clock which measure date-less time (only day of the week and hours, minutes and seconds). This is used for scheduling of water heater stated or temperatures (available only in original app). For that, it's necessary that water heater has proper time set up. Unfortunately, the time is lost after power outage and needs to be set up again.
 
-By enabling time ESPHome component (see YAML), we use the time from the HomeAssistant to adjust/setup the time if it differs more than 30 seconds. That keeps the the water heater time in sync with HomeAssistant.
+Add a `time:` source (for example `platform: homeassistant`) and set `time_id` on each `smartboiler` entry to the same `id` as that clock. The firmware then compares the heater clock to ESPHome and adjusts if it differs by more than 30 seconds, keeping the heater aligned with Home Assistant.
 
 ### How to reset UUID
 

--- a/components/smartboiler/SBProtocol.cpp
+++ b/components/smartboiler/SBProtocol.cpp
@@ -20,6 +20,18 @@ void SBProtocolRequest::write_le(uint32_t s) {
   this->mData.push_back((uint8_t) ((s >> 24) & 255));
 }
 
+// write value in Little Endian
+void SBProtocolRequest::write_le(uint64_t s) {
+  this->mData.push_back((uint8_t) (s & 255));
+  this->mData.push_back((uint8_t) ((s >> 8) & 255));
+  this->mData.push_back((uint8_t) ((s >> 16) & 255));
+  this->mData.push_back((uint8_t) ((s >> 24) & 255));
+  this->mData.push_back((uint8_t) ((s >> 32) & 255));
+  this->mData.push_back((uint8_t) ((s >> 40) & 255));
+  this->mData.push_back((uint8_t) ((s >> 48) & 255));
+  this->mData.push_back((uint8_t) ((s >> 56) & 255));
+}
+
 void SBProtocolRequest::writeString(const std::string &s) {
   for (size_t i = 0; i < s.size(); i++) {
     this->mData.push_back(s[i]);

--- a/components/smartboiler/__init__.py
+++ b/components/smartboiler/__init__.py
@@ -42,13 +42,13 @@ CONFIG_SCHEMA = cv.polling_component_schema('600s').extend({
     cv.Optional(CONF_TEMP2): sensor.sensor_schema(unit_of_measurement=UNIT_CELSIUS, icon=ICON_THERMOMETER, accuracy_decimals=1).extend(),
     cv.Optional(CONF_HDO_LOW_TARIFF, {"name": "HDO"}): binary_sensor.binary_sensor_schema().extend(),
     cv.Optional(CONF_HEAT_ON, {"name":"Heating", "icon": "mdi:radiator"}): binary_sensor.binary_sensor_schema().extend(),
-    cv.Optional(CONF_MODE): select.SELECT_SCHEMA.extend({
+    cv.Optional(CONF_MODE): select.select_schema().extend({
         cv.GenerateID(): cv.declare_id(SmartBoilerModeSelect),
     }),
-    cv.Optional(CONF_THERMOSTAT): climate.CLIMATE_SCHEMA.extend({
+    cv.Optional(CONF_THERMOSTAT): climate.climate_schema().extend({
         cv.GenerateID(): cv.declare_id(SmartBoilerThermostat),
     }),
-    cv.Optional(CONF_PIN, {"name": "Pairing PIN", "mode": "BOX", "icon": "mdi:lock"}): number.NUMBER_SCHEMA.extend({
+    cv.Optional(CONF_PIN, {"name": "Pairing PIN", "mode": "BOX", "icon": "mdi:lock"}): number.number_schema().extend({
         cv.GenerateID(): cv.declare_id(SmartBoilerPinInput),
     }),
     cv.Optional(CONF_STATE, {"name": "State", "icon": "mdi:connection" }): text_sensor.text_sensor_schema().extend(),

--- a/components/smartboiler/__init__.py
+++ b/components/smartboiler/__init__.py
@@ -42,13 +42,13 @@ CONFIG_SCHEMA = cv.polling_component_schema('600s').extend({
     cv.Optional(CONF_TEMP2): sensor.sensor_schema(unit_of_measurement=UNIT_CELSIUS, icon=ICON_THERMOMETER, accuracy_decimals=1).extend(),
     cv.Optional(CONF_HDO_LOW_TARIFF, {"name": "HDO"}): binary_sensor.binary_sensor_schema().extend(),
     cv.Optional(CONF_HEAT_ON, {"name":"Heating", "icon": "mdi:radiator"}): binary_sensor.binary_sensor_schema().extend(),
-    cv.Optional(CONF_MODE): select.select_schema().extend({
+    cv.Optional(CONF_MODE): select.select_schema(SmartBoiler).extend({
         cv.GenerateID(): cv.declare_id(SmartBoilerModeSelect),
     }),
-    cv.Optional(CONF_THERMOSTAT): climate.climate_schema().extend({
+    cv.Optional(CONF_THERMOSTAT): climate.climate_schema(SmartBoiler).extend({
         cv.GenerateID(): cv.declare_id(SmartBoilerThermostat),
     }),
-    cv.Optional(CONF_PIN, {"name": "Pairing PIN", "mode": "BOX", "icon": "mdi:lock"}): number.number_schema().extend({
+    cv.Optional(CONF_PIN, {"name": "Pairing PIN", "mode": "BOX", "icon": "mdi:lock"}): number.number_schema(SmartBoiler).extend({
         cv.GenerateID(): cv.declare_id(SmartBoilerPinInput),
     }),
     cv.Optional(CONF_STATE, {"name": "State", "icon": "mdi:connection" }): text_sensor.text_sensor_schema().extend(),

--- a/components/smartboiler/__init__.py
+++ b/components/smartboiler/__init__.py
@@ -3,7 +3,7 @@ import esphome.config_validation as cv
 from esphome.components import (
     ble_client, sensor,
     select, binary_sensor,
-    climate, number, text_sensor
+    climate, number, text_sensor, time as time_,
 )
 from esphome.const import (
     CONF_ID,CONF_STATE, CONF_PIN,
@@ -29,6 +29,7 @@ CONF_THERMOSTAT = 'thermostat'
 CONF_CONSUMPTION = 'consumption'
 CONF_BNAME = "b_name"
 CONF_ANODE_VOLTAGE = 'anode_voltage'
+CONF_TIME_ID = 'time_id'
 
 smartboiler_controller_ns = cg.esphome_ns.namespace('sb')
 
@@ -68,6 +69,7 @@ CONFIG_SCHEMA = cv.polling_component_schema('600s').extend({
             icon=ICON_FLASH,
             accuracy_decimals=3,
             state_class=STATE_CLASS_MEASUREMENT).extend(),
+    cv.Optional(CONF_TIME_ID): cv.use_id(time_.RealTimeClock),
 }).extend(ble_client.BLE_CLIENT_SCHEMA)
 
 async def to_code(config):
@@ -130,3 +132,7 @@ async def to_code(config):
         name = cg.new_Pvariable(config[CONF_BNAME][CONF_ID])
         await text_sensor.register_text_sensor(name, config[CONF_BNAME])
         cg.add(var.set_name(name))
+
+    if CONF_TIME_ID in config:
+        rtc = await cg.get_variable(config[CONF_TIME_ID])
+        cg.add(var.set_time_clock(rtc))

--- a/components/smartboiler/smartboiler.cpp
+++ b/components/smartboiler/smartboiler.cpp
@@ -2,8 +2,6 @@
 #include "esphome/core/application.h"
 #include <string>
 
-
-
 // Make time component include conditional
 #ifdef USE_TIME
 #include "esphome/components/time/real_time_clock.h"

--- a/components/smartboiler/smartboiler.cpp
+++ b/components/smartboiler/smartboiler.cpp
@@ -496,15 +496,14 @@ void SmartBoiler::process_command_queue_() {
 std::string SmartBoiler::generateUUID() {
   const char hex_chars[] = "0123456789ABCDEF";
   std::string uid;
-  uid.reserve(6);  // chceme 6 znaků
-
+  uid.reserve(6);
   for (int i = 0; i < 6; i++) {
-    uint8_t val = random(0, 16);   // náhodná hodnota 0–15
-    uid += hex_chars[val];         // přidej odpovídající hex znak
+    uid += hex_chars[random(0,16)];
   }
-
   return uid;
 }
+
+
 
 void SmartBoiler::send_pin(uint32_t pin) {
   ESP_LOGD(TAG, "Sending PIN to water heater.");

--- a/components/smartboiler/smartboiler.cpp
+++ b/components/smartboiler/smartboiler.cpp
@@ -504,10 +504,13 @@ std::string SmartBoiler::generateUUID() {
   md5.add(sbuf);
   md5.calculate();
 
-  // Arduino String → std::string
-  std::string hash = std::string(md5.toString().c_str());
+  // Ulož nejprve do Arduino String
+  String hashStr = md5.toString();
 
-  return hash.substr(0, 6);  // prvních 6 znaků jako UID
+  // Převod na std::string
+  std::string hashStd(hashStr.c_str());
+
+  return hashStd.substr(0, 6);  // prvních 6 znaků jako UID
 }
 
 

--- a/components/smartboiler/smartboiler.cpp
+++ b/components/smartboiler/smartboiler.cpp
@@ -504,8 +504,9 @@ std::string SmartBoiler::generateUUID() {
   md5.add(sbuf);
   md5.calculate();
 
-  std::string hash = md5.toString(); // hexadecimální řetězec
-  return hash.substr(0, 6);           // vrátí prvních 6 znaků jako UID
+  String hashStr = md5.toString();          // Arduino String
+  std::string hash(hashStr.c_str());        // převod na std::string
+  return hash.substr(0, 6);                 // prvních 6 znaků jako UID
 }
 
 

--- a/components/smartboiler/smartboiler.cpp
+++ b/components/smartboiler/smartboiler.cpp
@@ -497,16 +497,17 @@ void SmartBoiler::process_command_queue_() {
  */
 std::string SmartBoiler::generateUUID() {
   char sbuf[16];
-  sprintf(sbuf, "%08X", random_uint32());  // vygeneruj náhodnou hodnotu
+  sprintf(sbuf, "%08X", random_uint32());  // náhodné číslo jako vstup
 
   MD5Builder md5;
   md5.begin();
   md5.add(sbuf);
   md5.calculate();
 
-  String hashStr = md5.toString();          // Arduino String
-  std::string hash(hashStr.c_str());        // převod na std::string
-  return hash.substr(0, 6);                 // prvních 6 znaků jako UID
+  // Arduino String → std::string
+  std::string hash = std::string(md5.toString().c_str());
+
+  return hash.substr(0, 6);  // prvních 6 znaků jako UID
 }
 
 

--- a/components/smartboiler/smartboiler.cpp
+++ b/components/smartboiler/smartboiler.cpp
@@ -1,6 +1,5 @@
 #include "smartboiler.h"
 #include "esphome/core/application.h"
-#include <MD5Builder.h>
 #include <string>
 
 
@@ -494,24 +493,18 @@ void SmartBoiler::process_command_queue_() {
   }
 }
 
-/**
- * Generate random UUID for this device.
- */
 std::string SmartBoiler::generateUUID() {
-  char sbuf[16];
-  sprintf(sbuf, "%08X", random_uint32());  // náhodné číslo jako vstup
+  const char hex_chars[] = "0123456789ABCDEF";
+  std::string uid;
+  uid.reserve(6);  // chceme 6 znaků
 
-  MD5Builder md5;
-  md5.begin();
-  md5.add(sbuf);
-  md5.calculate();
+  for (int i = 0; i < 6; i++) {
+    uint8_t val = random(0, 16);   // náhodná hodnota 0–15
+    uid += hex_chars[val];         // přidej odpovídající hex znak
+  }
 
-  String hashStr = md5.toString();
-  std::string hashStd(hashStr.c_str());
-
-  return hashStd.substr(0, 6);
+  return uid;
 }
-
 
 void SmartBoiler::send_pin(uint32_t pin) {
   ESP_LOGD(TAG, "Sending PIN to water heater.");

--- a/components/smartboiler/smartboiler.cpp
+++ b/components/smartboiler/smartboiler.cpp
@@ -112,8 +112,9 @@ void SmartBoiler::on_set_hdo_enabled(const std::string &payload) {
 #ifdef USE_TIME
 void SmartBoiler::on_set_time(int64_t time_adjustment) {
   ESP_LOGI(TAG, "Adjusting time by: %ld seconds", time_adjustment);
-  auto cmd = SBProtocolRequest(SBC_PACKET_HOME_TIME, this->mPacketUid++);
+  auto cmd = SBProtocolRequest(SBC_PACKET_HOME_SETTIME, this->mPacketUid++);
   cmd.write_le(uint64_t(time_adjustment));
+  this->enqueue_command_(cmd);
 }
 #endif
 
@@ -395,8 +396,8 @@ void SmartBoiler::handle_incoming(const uint8_t *value, uint16_t value_len) {
                                             current_time.second;
           
           // Calculate time difference in seconds
-          int64_t time_difference = current_seconds_since_monday - water_heater_seconds_since_monday;
-          
+          int64_t time_difference = water_heater_seconds_since_monday - current_seconds_since_monday;
+
           ESP_LOGD(TAG, "Current ESPHome time: %04d-%02d-%02d %02d:%02d:%02d (day: %d, seconds since Monday: %d)", 
                    current_time.year, current_time.month, current_time.day_of_month,
                    current_time.hour, current_time.minute, current_time.second,

--- a/components/smartboiler/smartboiler.cpp
+++ b/components/smartboiler/smartboiler.cpp
@@ -78,7 +78,7 @@ void SmartBoiler::send_to_boiler(SBProtocolRequest request) {
                                          ESP_GATT_WRITE_TYPE_NO_RSP, ESP_GATT_AUTH_REQ_NONE);
 
   if (status)
-    ESP_LOGW(TAG, "[%s] esp_ble_gattc_write_char failed, status=%d", this->parent_->address_str().c_str(), status);
+    ESP_LOGW(TAG, "[%s] esp_ble_gattc_write_char failed, status=%d", this->parent_->address_str(), status);
 }
 
 void SmartBoiler::on_set_temperature(uint8_t temp) {
@@ -123,12 +123,12 @@ void SmartBoiler::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t 
   switch (event) {
     case ESP_GATTC_OPEN_EVT: {
       if (param->open.status == ESP_GATT_OK) {
-        ESP_LOGI(TAG, "[%s] Connected", this->parent_->address_str().c_str());
+        ESP_LOGI(TAG, "[%s] Connected", this->parent_->address_str());
       }
       break;
     }
     case ESP_GATTC_DISCONNECT_EVT: {
-      ESP_LOGI(TAG, "[%s] Disconnected", this->parent_->address_str().c_str());
+      ESP_LOGI(TAG, "[%s] Disconnected", this->parent_->address_str());
       this->set_state(ConnectionState::DISCONNECTED);
       break;
     }
@@ -136,7 +136,7 @@ void SmartBoiler::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t 
       auto chr = this->parent_->get_characteristic(SB_MAIN_SERVICE_UUID, SB_MAIN_CHARACTERISTIC_UUID);
       if (chr == nullptr) {
         ESP_LOGE(TAG, "[%s] No main service found at device, not a SmartBoiler..?",
-                 this->parent_->address_str().c_str());
+                 this->parent_->address_str());
         this->parent_->disconnect();
         break;
       }
@@ -147,7 +147,7 @@ void SmartBoiler::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t 
 
       if (chr == nullptr) {
         ESP_LOGE(TAG, "[%s] No logging service found at device, not a SmartBoiler..?",
-                 this->parent_->address_str().c_str());
+                 this->parent_->address_str());
         this->parent_->disconnect();
         break;
       }

--- a/components/smartboiler/smartboiler.cpp
+++ b/components/smartboiler/smartboiler.cpp
@@ -2,6 +2,14 @@
 #include "esphome/core/application.h"
 #include "esphome/components/md5/md5.h"
 
+// Make time component include conditional
+#ifdef USE_TIME
+#include "esphome/components/time/real_time_clock.h"
+// Add this line to declare the external time component
+extern esphome::time::RealTimeClock *esphome_time;
+#endif
+
+
 #define UUID_LENGTH 6
 
 static const char *const TAG = "smartboiler";
@@ -100,6 +108,14 @@ void SmartBoiler::on_set_hdo_enabled(const std::string &payload) {
   cmd.write_le(uint32_t(*hdoOpt ? 1 : 0));
   this->enqueue_command_(cmd);
 }
+
+#ifdef USE_TIME
+void SmartBoiler::on_set_time(int64_t time_adjustment) {
+  ESP_LOGI(TAG, "Adjusting time by: %ld seconds", time_adjustment);
+  auto cmd = SBProtocolRequest(SBC_PACKET_HOME_TIME, this->mPacketUid++);
+  cmd.write_le(uint64_t(time_adjustment));
+}
+#endif
 
 void SmartBoiler::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
                                       esp_ble_gattc_cb_param_t *param) {
@@ -330,15 +346,68 @@ void SmartBoiler::handle_incoming(const uint8_t *value, uint16_t value_len) {
       ESP_LOGW(TAG, "water heater indicates that the last request has failed");
       break;
     }
+    // Time is sent by water heater every 5 seconds.
     case SBPacket::SBC_PACKET_HOME_TIME: {
       // time is in format D.HH:MM:SS
       // first byte is day
       auto day = result.mString[0] - '0';
       // the rest is a string
       auto time = result.mString.substr(2,8);
+      
       char buffer[30];
       sprintf(buffer, "%s, %s", this->day_to_string(day), time.c_str());
       ESP_LOGD(TAG, "Water heater internal time: %s", buffer);
+      
+#ifdef USE_TIME
+      // Parse the time string from water heater using strptime
+      ESPTime water_heater_time;
+      if (ESPTime::strptime(time.c_str(), water_heater_time)) {
+        // Get current time from ESPHome time component
+        auto current_time = id(esphome_time).now();
+        
+        if (current_time.is_valid()) {
+          // Convert water heater time to seconds since last Monday
+          // Water heater: 0=Monday, 1=Tuesday, ..., 6=Sunday
+          int water_heater_seconds_since_monday = (day * 24 * 3600) + 
+                                                 (water_heater_time.hour * 3600) + 
+                                                 (water_heater_time.minute * 60) + 
+                                                 water_heater_time.second;
+          
+          // Convert current time to seconds since last Monday
+          // ESPHome: 1=Sunday, 2=Monday, ..., 7=Saturday
+          int current_day_of_week = current_time.day_of_week; // 1=Sunday, 2=Monday, etc.
+          int days_since_monday = (current_day_of_week == 1) ? 6 : (current_day_of_week - 2);
+          int current_seconds_since_monday = (days_since_monday * 24 * 3600) + 
+                                            (current_time.hour * 3600) + 
+                                            (current_time.minute * 60) + 
+                                            current_time.second;
+          
+          // Calculate time difference in seconds
+          int64_t time_difference = current_seconds_since_monday - water_heater_seconds_since_monday;
+          
+          ESP_LOGD(TAG, "Current ESPHome time: %04d-%02d-%02d %02d:%02d:%02d (day: %d, seconds since Monday: %d)", 
+                   current_time.year, current_time.month, current_time.day_of_month,
+                   current_time.hour, current_time.minute, current_time.second,
+                   current_day_of_week, current_seconds_since_monday);
+          
+          char buffer[50];
+          sprintf(buffer, "%s, %s (diff: %ld sec)", this->day_to_string(day), time.c_str(), time_difference);
+          ESP_LOGD(TAG, "Water heater internal time: %s", buffer);
+          
+          // If the time difference is too large, adjust the time
+          if (time_difference > TIME_ADJUSTMENT_THRESHOLD || time_difference < -TIME_ADJUSTMENT_THRESHOLD) {
+            ESP_LOGI(TAG, "Time difference is too large, adjusting time by %ld seconds", time_difference);
+            this->on_set_time(time_difference);
+          }
+        } else {
+          ESP_LOGW(TAG, "Current time not available from ESPHome time component");
+        }
+      } else {
+        ESP_LOGW(TAG, "Failed to parse water heater time: %s", time.c_str());
+      }
+#else
+      ESP_LOGD(TAG, "Time component not available - time synchronization disabled");
+#endif
       break;
     }
     default:

--- a/components/smartboiler/smartboiler.cpp
+++ b/components/smartboiler/smartboiler.cpp
@@ -1,6 +1,8 @@
 #include "smartboiler.h"
 #include "esphome/core/application.h"
 #include <MD5Builder.h>
+#include <string>
+
 
 
 // Make time component include conditional
@@ -504,13 +506,10 @@ std::string SmartBoiler::generateUUID() {
   md5.add(sbuf);
   md5.calculate();
 
-  // Ulož nejprve do Arduino String
   String hashStr = md5.toString();
-
-  // Převod na std::string
   std::string hashStd(hashStr.c_str());
 
-  return hashStd.substr(0, 6);  // prvních 6 znaků jako UID
+  return hashStd.substr(0, 6);
 }
 
 

--- a/components/smartboiler/smartboiler.cpp
+++ b/components/smartboiler/smartboiler.cpp
@@ -444,8 +444,8 @@ esphome::climate::ClimateTraits SmartBoilerThermostat::traits() {
   rv.set_visual_min_temperature(MIN_TEMP);
   rv.set_visual_max_temperature(MAX_TEMP);
   rv.set_visual_temperature_step(1);
-  rv.set_supports_current_temperature(true);
-  rv.set_supports_action(true);
+  rv.add_feature_flags(climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE);
+  rv.add_feature_flags(climate::CLIMATE_SUPPORTS_ACTION);
   rv.set_supported_modes({climate::CLIMATE_MODE_OFF, climate::CLIMATE_MODE_HEAT});
 
   return rv;
@@ -462,7 +462,7 @@ void SmartBoilerThermostat::publish_current_temp(float temp) {
 }
 
 void SmartBoilerThermostat::publish_action(bool heating) {
-  if (get_parent()->mode_select_->state == "STOP")
+  if (get_parent()->mode_select_->current_option() == "STOP")
     this->action = esphome::climate::CLIMATE_ACTION_OFF;
   else if (heating)
     this->action = esphome::climate::CLIMATE_ACTION_HEATING;

--- a/components/smartboiler/smartboiler.cpp
+++ b/components/smartboiler/smartboiler.cpp
@@ -1,6 +1,7 @@
 #include "smartboiler.h"
 #include "esphome/core/application.h"
-#include "esphome/components/md5/md5.h"
+#include <MD5Builder.h>
+
 
 // Make time component include conditional
 #ifdef USE_TIME
@@ -496,16 +497,17 @@ void SmartBoiler::process_command_queue_() {
  */
 std::string SmartBoiler::generateUUID() {
   char sbuf[16];
-  md5::MD5Digest md5{};
-  md5.init();
-  sprintf(sbuf, "%08X", random_uint32());
-  md5.add(sbuf, 8);
+  sprintf(sbuf, "%08X", random_uint32());  // vygeneruj náhodnou hodnotu
+
+  MD5Builder md5;
+  md5.begin();
+  md5.add(sbuf);
   md5.calculate();
-  md5.get_hex(sbuf);
-  ESP_LOGV(TAG, "Auth: Nonce is %s", sbuf);
-  std::string s(sbuf);
-  return s.substr(0, 6);
+
+  std::string hash = md5.toString(); // hexadecimální řetězec
+  return hash.substr(0, 6);           // vrátí prvních 6 znaků jako UID
 }
+
 
 void SmartBoiler::send_pin(uint32_t pin) {
   ESP_LOGD(TAG, "Sending PIN to water heater.");

--- a/components/smartboiler/smartboiler.cpp
+++ b/components/smartboiler/smartboiler.cpp
@@ -2,13 +2,9 @@
 #include "esphome/core/application.h"
 #include "esphome/components/md5/md5.h"
 
-// Make time component include conditional
 #ifdef USE_TIME
 #include "esphome/components/time/real_time_clock.h"
-// Add this line to declare the external time component
-extern esphome::time::RealTimeClock *esphome_time;
 #endif
-
 
 #define UUID_LENGTH 6
 
@@ -375,9 +371,11 @@ void SmartBoiler::handle_incoming(const uint8_t *value, uint16_t value_len) {
       // Parse the time string from water heater using strptime
       ESPTime water_heater_time;
       if (ESPTime::strptime(time.c_str(), water_heater_time)) {
-        // Get current time from ESPHome time component
-        auto current_time = id(esphome_time).now();
-        
+        if (this->time_clock_ == nullptr) {
+          ESP_LOGW(TAG, "No time_id configured on smartboiler; time sync skipped");
+        } else {
+        auto current_time = this->time_clock_->now();
+
         if (current_time.is_valid()) {
           // Convert water heater time to seconds since last Monday
           // Water heater: 0=Monday, 1=Tuesday, ..., 6=Sunday
@@ -414,6 +412,7 @@ void SmartBoiler::handle_incoming(const uint8_t *value, uint16_t value_len) {
           }
         } else {
           ESP_LOGW(TAG, "Current time not available from ESPHome time component");
+        }
         }
       } else {
         ESP_LOGW(TAG, "Failed to parse water heater time: %s", time.c_str());

--- a/components/smartboiler/smartboiler.cpp
+++ b/components/smartboiler/smartboiler.cpp
@@ -495,7 +495,7 @@ std::string SmartBoiler::generateUUID() {
   std::string uid;
   uid.reserve(6);
   for (int i = 0; i < 6; i++) {
-    uid += hex_chars[random(0,16)];
+    uid += hex_chars[random_uint32() & 0xF];
   }
   return uid;
 }

--- a/components/smartboiler/smartboiler.h
+++ b/components/smartboiler/smartboiler.h
@@ -13,6 +13,8 @@
 #include "esphome/components/number/number.h"
 #include "SBProtocol.h"
 
+#define TIME_ADJUSTMENT_THRESHOLD 30
+
 namespace esphome {
 namespace sb {
 
@@ -78,6 +80,7 @@ class SmartBoiler : public PollingComponent,
   const char *day_to_string(uint8_t day);
   uint8_t convert_action_to_mode(const std::string &payload);
   std::string convert_mode_to_action(const uint8_t mode);
+  void on_set_time(int64_t time_adjustment);
 
   ESPPreferenceObject pref_;
   // state of the connection

--- a/components/smartboiler/smartboiler.h
+++ b/components/smartboiler/smartboiler.h
@@ -58,6 +58,7 @@ class SmartBoiler : public PollingComponent,
   void set_state(text_sensor::TextSensor *t) { state_txt_ = t; }
   void set_version(text_sensor::TextSensor *t) { version_ = t; }
   void set_name(text_sensor::TextSensor *t) { name_ = t; }
+  void set_anode_voltage(sensor::Sensor *s) { anode_voltage_sensor_ = s; }
 
  protected:
   void set_uid(const std::string &uid) { this->uid_ = uid; }
@@ -101,6 +102,7 @@ class SmartBoiler : public PollingComponent,
   sensor::Sensor *temperature_sensor_1_sensor_ = nullptr;
   sensor::Sensor *temperature_sensor_2_sensor_ = nullptr;
   sensor::Sensor *consumption_sensor_ = nullptr;
+  sensor::Sensor *anode_voltage_sensor_ = nullptr;
 
   binary_sensor::BinarySensor *hdo_low_tariff_sensor_ = nullptr;
   binary_sensor::BinarySensor *heat_on_sensor_ = nullptr;

--- a/components/smartboiler/smartboiler.h
+++ b/components/smartboiler/smartboiler.h
@@ -16,6 +16,9 @@
 #define TIME_ADJUSTMENT_THRESHOLD 30
 
 namespace esphome {
+namespace time {
+class RealTimeClock;
+}
 namespace sb {
 
 static const uint8_t MIN_TEMP = 40;
@@ -59,6 +62,7 @@ class SmartBoiler : public PollingComponent,
   void set_version(text_sensor::TextSensor *t) { version_ = t; }
   void set_name(text_sensor::TextSensor *t) { name_ = t; }
   void set_anode_voltage(sensor::Sensor *s) { anode_voltage_sensor_ = s; }
+  void set_time_clock(time::RealTimeClock *rtc) { this->time_clock_ = rtc; }
 
  protected:
   void set_uid(const std::string &uid) { this->uid_ = uid; }
@@ -112,6 +116,7 @@ class SmartBoiler : public PollingComponent,
   SmartBoilerModeSelect *mode_select_ = nullptr;
   SmartBoilerThermostat *thermostat_ = nullptr;
   SmartBoilerPinInput *mPin_ = nullptr;
+  time::RealTimeClock *time_clock_{nullptr};
 
   friend class SmartBoilerModeSelect;
   friend class SmartBoilerThermostat;

--- a/example.yaml
+++ b/example.yaml
@@ -4,7 +4,8 @@ esphome:
 esp32:
   board: nodemcu-32s
   framework:
-    type: arduino
+    type: esp-idf
+    version: recommended
 
 substitutions:
   mac_water_heater: XX:XX:XX:XX:XX:XX

--- a/example.yaml
+++ b/example.yaml
@@ -16,6 +16,11 @@ external_components:
       url: https://github.com/pedobry/esphome-smartboiler
     components: [smartboiler]
 
+# Enable time component. This will be used to set the time on the water heater.
+time:
+  - platform: homeassistant
+    id: esphome_time
+
 # Enable Home Assistant API
 api:
   encryption:

--- a/example.yaml
+++ b/example.yaml
@@ -32,6 +32,7 @@ ble_client:
 
 smartboiler:
   - ble_client_id: drazice_okhe
+    time_id: esphome_time
     temp1:
       name: "Water heater temp1"
     temp2:

--- a/example_multiple.yaml
+++ b/example_multiple.yaml
@@ -20,6 +20,11 @@ external_components:
 logger:
   level: info
 
+# Enable time component. This will be used to set the time on the water heaters.
+time:
+  - platform: homeassistant
+    id: esphome_time
+
 # Enable Home Assistant API
 api:
   encryption:

--- a/example_multiple.yaml
+++ b/example_multiple.yaml
@@ -4,7 +4,8 @@ esphome:
 esp32:
   board: nodemcu-32s
   framework:
-    type: arduino
+    type: esp-idf
+    version: recommended
 
 substitutions:
   mac_water_heater_1: XX:XX:XX:XX:XX:XX

--- a/example_multiple.yaml
+++ b/example_multiple.yaml
@@ -38,6 +38,7 @@ ble_client:
 
 smartboiler:
   - ble_client_id: drazice_okhe_1
+    time_id: esphome_time
     temp1:
       name: "Water heater 1 temp1"
     temp2:
@@ -61,6 +62,7 @@ smartboiler:
     consumption:
       name: "Water heater 1 energy"
   - ble_client_id: drazice_okhe_2
+    time_id: esphome_time
     temp1:
       name: "Water heater 2 temp1"
     temp2:


### PR DESCRIPTION
This PR add a code to automatically sets water heater time if it drifts more tha 30 seconds. The main reason is to set the time after power outage when water heater resets it's time.

It also changes framework from arduino to esp-idf as that's not recommended and should also provide smaller images.

The time sync is enabled by adding:
```
# Enable time component. This will be used to set the time on the water heater.
time:
  - platform: homeassistant
    id: esphome_time
```